### PR TITLE
Ensure Address is based on WIREGUARD_START_IP

### DIFF
--- a/src/createConfig.ts
+++ b/src/createConfig.ts
@@ -2,6 +2,8 @@ import genkey from './backend/_utils/genKey'
 import fs from 'fs'
 
 const path = '/etc/wireguard/wg0.conf'
+const ip = process.env.WIREGUARD_START_IP?.split('.')
+const wgAddress = `${ip[0]}.${ip[1]}.0.1/16`
 
 const delay = (ms: number): Promise<void> => {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -9,7 +11,7 @@ const delay = (ms: number): Promise<void> => {
 
 const config = (privateKey: string): string => {
   return `[Interface]
-Address = 10.69.0.1/16
+Address = ${wgAddress}
 SaveConfig = true
 PostUp = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT; iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE


### PR DESCRIPTION
This PR sets the config of the `Address` value of the Wireguard `[Interface]` is based on the `WIREGUARD_START_IP` environment variable in the same way that `[Peer]` values as the value is currently hard coded.